### PR TITLE
Add RTSP, RTMP, HLS, WebRTC default path support

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -216,14 +216,16 @@ type Conf struct {
 	ServerKey         string      `json:"serverKey"`
 	ServerCert        string      `json:"serverCert"`
 	AuthMethods       AuthMethods `json:"authMethods"`
+	RTSPDefaultPath   string      `json:"rtspDefaultPath"`
 
 	// RTMP
-	RTMPDisable    bool       `json:"rtmpDisable"`
-	RTMPAddress    string     `json:"rtmpAddress"`
-	RTMPEncryption Encryption `json:"rtmpEncryption"`
-	RTMPSAddress   string     `json:"rtmpsAddress"`
-	RTMPServerKey  string     `json:"rtmpServerKey"`
-	RTMPServerCert string     `json:"rtmpServerCert"`
+	RTMPDisable     bool       `json:"rtmpDisable"`
+	RTMPAddress     string     `json:"rtmpAddress"`
+	RTMPEncryption  Encryption `json:"rtmpEncryption"`
+	RTMPSAddress    string     `json:"rtmpsAddress"`
+	RTMPServerKey   string     `json:"rtmpServerKey"`
+	RTMPServerCert  string     `json:"rtmpServerCert"`
+	RTMPDefaultPath string     `json:"rtmpDefaultPath"`
 
 	// HLS
 	HLSDisable         bool           `json:"hlsDisable"`
@@ -240,6 +242,7 @@ type Conf struct {
 	HLSAllowOrigin     string         `json:"hlsAllowOrigin"`
 	HLSTrustedProxies  IPsOrCIDRs     `json:"hlsTrustedProxies"`
 	HLSDirectory       string         `json:"hlsDirectory"`
+	HLSDefaultPath     string         `json:"hlsDefaultPath"`
 
 	// WebRTC
 	WebRTCDisable           bool       `json:"webrtcDisable"`
@@ -253,6 +256,7 @@ type Conf struct {
 	WebRTCICEHostNAT1To1IPs []string   `json:"webrtcICEHostNAT1To1IPs"`
 	WebRTCICEUDPMuxAddress  string     `json:"webrtcICEUDPMuxAddress"`
 	WebRTCICETCPMuxAddress  string     `json:"webrtcICETCPMuxAddress"`
+	WebRTCDefaultPath       string     `json:"webrtcDefaultPath"`
 
 	// paths
 	Paths map[string]*PathConf `json:"paths"`

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -279,6 +279,7 @@ func (p *Core) createResources(initial bool) error {
 				"",
 				"",
 				p.conf.RTSPAddress,
+				p.conf.RTSPDefaultPath,
 				p.conf.Protocols,
 				p.conf.RunOnConnect,
 				p.conf.RunOnConnectRestart,
@@ -316,6 +317,7 @@ func (p *Core) createResources(initial bool) error {
 				p.conf.ServerCert,
 				p.conf.ServerKey,
 				p.conf.RTSPAddress,
+				p.conf.RTSPDefaultPath,
 				p.conf.Protocols,
 				p.conf.RunOnConnect,
 				p.conf.RunOnConnectRestart,
@@ -345,6 +347,7 @@ func (p *Core) createResources(initial bool) error {
 				"",
 				"",
 				p.conf.RTSPAddress,
+				p.conf.RTMPDefaultPath,
 				p.conf.RunOnConnect,
 				p.conf.RunOnConnectRestart,
 				p.externalCmdPool,
@@ -373,6 +376,7 @@ func (p *Core) createResources(initial bool) error {
 				p.conf.RTMPServerCert,
 				p.conf.RTMPServerKey,
 				p.conf.RTSPAddress,
+				p.conf.RTMPDefaultPath,
 				p.conf.RunOnConnect,
 				p.conf.RunOnConnectRestart,
 				p.externalCmdPool,
@@ -404,6 +408,7 @@ func (p *Core) createResources(initial bool) error {
 				p.conf.HLSAllowOrigin,
 				p.conf.HLSTrustedProxies,
 				p.conf.HLSDirectory,
+				p.conf.HLSDefaultPath,
 				p.conf.ReadTimeout,
 				p.conf.ReadBufferCount,
 				p.pathManager,
@@ -436,6 +441,7 @@ func (p *Core) createResources(initial bool) error {
 				p.conf.WebRTCICEHostNAT1To1IPs,
 				p.conf.WebRTCICEUDPMuxAddress,
 				p.conf.WebRTCICETCPMuxAddress,
+				p.conf.WebRTCDefaultPath,
 			)
 			if err != nil {
 				return err
@@ -505,6 +511,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.Encryption != p.conf.Encryption ||
 		newConf.ExternalAuthenticationURL != p.conf.ExternalAuthenticationURL ||
 		newConf.RTSPAddress != p.conf.RTSPAddress ||
+		newConf.RTSPDefaultPath != p.conf.RTSPDefaultPath ||
 		!reflect.DeepEqual(newConf.AuthMethods, p.conf.AuthMethods) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteTimeout != p.conf.WriteTimeout ||
@@ -527,6 +534,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.Encryption != p.conf.Encryption ||
 		newConf.ExternalAuthenticationURL != p.conf.ExternalAuthenticationURL ||
 		newConf.RTSPSAddress != p.conf.RTSPSAddress ||
+		newConf.RTSPDefaultPath != p.conf.RTSPDefaultPath ||
 		!reflect.DeepEqual(newConf.AuthMethods, p.conf.AuthMethods) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteTimeout != p.conf.WriteTimeout ||
@@ -544,6 +552,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.RTMPDisable != p.conf.RTMPDisable ||
 		newConf.RTMPEncryption != p.conf.RTMPEncryption ||
 		newConf.RTMPAddress != p.conf.RTMPAddress ||
+		newConf.RTMPDefaultPath != p.conf.RTMPDefaultPath ||
 		newConf.ExternalAuthenticationURL != p.conf.ExternalAuthenticationURL ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteTimeout != p.conf.WriteTimeout ||
@@ -565,6 +574,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.RTMPServerCert != p.conf.RTMPServerCert ||
 		newConf.RTMPServerKey != p.conf.RTMPServerKey ||
 		newConf.RTSPAddress != p.conf.RTSPAddress ||
+		newConf.RTMPDefaultPath != p.conf.RTMPDefaultPath ||
 		newConf.RunOnConnect != p.conf.RunOnConnect ||
 		newConf.RunOnConnectRestart != p.conf.RunOnConnectRestart ||
 		closeMetrics ||
@@ -586,6 +596,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.HLSAllowOrigin != p.conf.HLSAllowOrigin ||
 		!reflect.DeepEqual(newConf.HLSTrustedProxies, p.conf.HLSTrustedProxies) ||
 		newConf.HLSDirectory != p.conf.HLSDirectory ||
+		newConf.HLSDefaultPath != p.conf.HLSDefaultPath ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.ReadBufferCount != p.conf.ReadBufferCount ||
 		closePathManager ||
@@ -607,7 +618,8 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		closePathManager ||
 		!reflect.DeepEqual(newConf.WebRTCICEHostNAT1To1IPs, p.conf.WebRTCICEHostNAT1To1IPs) ||
 		newConf.WebRTCICEUDPMuxAddress != p.conf.WebRTCICEUDPMuxAddress ||
-		newConf.WebRTCICETCPMuxAddress != p.conf.WebRTCICETCPMuxAddress
+		newConf.WebRTCICETCPMuxAddress != p.conf.WebRTCICETCPMuxAddress ||
+		newConf.WebRTCDefaultPath != p.conf.WebRTCDefaultPath
 
 	closeAPI := newConf == nil ||
 		newConf.API != p.conf.API ||

--- a/internal/core/rtmp_conn.go
+++ b/internal/core/rtmp_conn.go
@@ -152,6 +152,7 @@ type rtmpConn struct {
 	isTLS                     bool
 	externalAuthenticationURL string
 	rtspAddress               string
+	defaultPath               string
 	readTimeout               conf.StringDuration
 	writeTimeout              conf.StringDuration
 	readBufferCount           int
@@ -177,6 +178,7 @@ func newRTMPConn(
 	isTLS bool,
 	externalAuthenticationURL string,
 	rtspAddress string,
+	defaultPath string,
 	readTimeout conf.StringDuration,
 	writeTimeout conf.StringDuration,
 	readBufferCount int,
@@ -194,6 +196,7 @@ func newRTMPConn(
 		isTLS:                     isTLS,
 		externalAuthenticationURL: externalAuthenticationURL,
 		rtspAddress:               rtspAddress,
+		defaultPath:               defaultPath,
 		readTimeout:               readTimeout,
 		writeTimeout:              writeTimeout,
 		readBufferCount:           readBufferCount,
@@ -310,6 +313,10 @@ func (c *rtmpConn) runInner(ctx context.Context) error {
 
 func (c *rtmpConn) runRead(ctx context.Context, u *url.URL) error {
 	pathName, query, rawQuery := pathNameAndQuery(u)
+
+	if pathName == "" {
+		pathName = strings.TrimSuffix(c.defaultPath, "/")
+	}
 
 	res := c.pathManager.readerAdd(pathReaderAddReq{
 		author:   c,

--- a/internal/core/rtmp_server.go
+++ b/internal/core/rtmp_server.go
@@ -54,6 +54,7 @@ type rtmpServer struct {
 	readBufferCount           int
 	isTLS                     bool
 	rtspAddress               string
+	defaultPath               string
 	runOnConnect              string
 	runOnConnectRestart       bool
 	externalCmdPool           *externalcmd.Pool
@@ -84,6 +85,7 @@ func newRTMPServer(
 	serverCert string,
 	serverKey string,
 	rtspAddress string,
+	defaultPath string,
 	runOnConnect string,
 	runOnConnectRestart bool,
 	externalCmdPool *externalcmd.Pool,
@@ -116,6 +118,7 @@ func newRTMPServer(
 		writeTimeout:              writeTimeout,
 		readBufferCount:           readBufferCount,
 		rtspAddress:               rtspAddress,
+		defaultPath:               defaultPath,
 		runOnConnect:              runOnConnect,
 		runOnConnectRestart:       runOnConnectRestart,
 		isTLS:                     isTLS,
@@ -202,6 +205,7 @@ outer:
 				s.isTLS,
 				s.externalAuthenticationURL,
 				s.rtspAddress,
+				s.defaultPath,
 				s.readTimeout,
 				s.writeTimeout,
 				s.readBufferCount,

--- a/internal/core/rtsp_server.go
+++ b/internal/core/rtsp_server.go
@@ -81,6 +81,7 @@ type rtspServer struct {
 	readTimeout               conf.StringDuration
 	isTLS                     bool
 	rtspAddress               string
+	defaultPath               string
 	protocols                 map[conf.Protocol]struct{}
 	runOnConnect              string
 	runOnConnectRestart       bool
@@ -117,6 +118,7 @@ func newRTSPServer(
 	serverCert string,
 	serverKey string,
 	rtspAddress string,
+	defaultPath string,
 	protocols map[conf.Protocol]struct{},
 	runOnConnect string,
 	runOnConnectRestart bool,
@@ -133,6 +135,7 @@ func newRTSPServer(
 		readTimeout:               readTimeout,
 		isTLS:                     isTLS,
 		rtspAddress:               rtspAddress,
+		defaultPath:               defaultPath,
 		protocols:                 protocols,
 		runOnConnect:              runOnConnect,
 		runOnConnectRestart:       runOnConnectRestart,
@@ -248,6 +251,7 @@ func (s *rtspServer) OnConnOpen(ctx *gortsplib.ServerHandlerOnConnOpenCtx) {
 	c := newRTSPConn(
 		s.externalAuthenticationURL,
 		s.rtspAddress,
+		s.defaultPath,
 		s.authMethods,
 		s.readTimeout,
 		s.runOnConnect,

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -98,6 +98,8 @@ serverKey: server.key
 serverCert: server.crt
 # Authentication methods.
 authMethods: [basic, digest]
+# If no stream path is given by a client, then use this default path.
+rtspDefaultPath:
 
 ###############################################
 # RTMP parameters
@@ -118,6 +120,8 @@ rtmpsAddress: :1936
 rtmpServerKey: server.key
 # Path to the server certificate. This is needed only when encryption is "strict" or "optional".
 rtmpServerCert: server.crt
+# If no stream path is given by a client, then use this default path.
+rtmpDefaultPath:
 
 ###############################################
 # HLS parameters
@@ -174,6 +178,8 @@ hlsTrustedProxies: []
 # This decreases performance, since reading from disk is less performant than
 # reading from RAM, but allows to save RAM.
 hlsDirectory: ''
+# If no stream path is given by a client, then use this default path.
+hlsDefaultPath:
 
 ###############################################
 # WebRTC parameters
@@ -218,6 +224,8 @@ webrtcICEUDPMuxAddress:
 # At the moment, setting this parameter forces usage of the TCP protocol,
 # which is not optimal for WebRTC.
 webrtcICETCPMuxAddress:
+# If no stream path is given by a client, then use this default path.
+webrtcDefaultPath:
 
 ###############################################
 # Path parameters


### PR DESCRIPTION
If no stream path is given by a client, then use the default path given in the config. Example:

- The server has the rtmpDefaultPath set in the config to "abcd" (without the quotation marks of course)
- The server is publishing a stream called "abcd", it can be read with the URL rtmp://serverhostname/abcd
- A client opens the URL rtmp://serverhostname/
- The server detects that the client has no path in the URL, so appends the default path "abcd", so it will be served to the client.