### PR TITLE
fix: metrics listener address sanitization

### DIFF
--- a/internal/core/metrics.go
+++ b/internal/core/metrics.go
@@ -43,7 +43,7 @@ func newMetrics(
 	readTimeout conf.StringDuration,
 	parent metricsParent,
 ) (*metrics, error) {
-	ln, err := net.Listen(restrictNetwork(restrictNetwork("tcp", address)))
+	ln, err := net.Listen(restrictNetwork("tcp", address))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In commit 3475762 from PR #1678 the restrictNetwork function was called twice for the metrics listening address only, which leads to 0.0.0.0 listeners not working properly for the metrics server.