### PR TITLE
Support RTSP configurable Range header

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -171,13 +171,10 @@ components:
     PathConf:
       type: object
       properties:
-        # source
         source:
           type: string
-        sourceProtocol:
-          type: string
-        sourceAnyPortEnable:
-          type: boolean
+
+        # general
         sourceFingerprint:
           type: string
         sourceOnDemand:
@@ -186,12 +183,46 @@ components:
           type: string
         sourceOnDemandCloseAfter:
           type: string
-        sourceRedirect:
+
+        # authentication
+        publishUser:
           type: string
+        publishPass:
+          type: string
+        publishIPs:
+          type: array
+          items:
+            type: string
+        readUser:
+          type: string
+        readPass:
+          type: string
+        readIPs:
+          type: array
+          items:
+            type: string
+
+        # publisher
         disablePublisherOverride:
           type: boolean
         fallback:
           type: string
+
+        # rtsp
+        sourceProtocol:
+          type: string
+        sourceAnyPortEnable:
+          type: boolean
+        rtspRangeType:
+          type: string
+        rtspRangeStart:
+          type: string
+
+        # redirect
+        sourceRedirect:
+          type: string
+
+        # raspberry pi camera
         rpiCameraCamID:
           type: integer
         rpiCameraWidth:
@@ -254,24 +285,6 @@ components:
           type: boolean
         rpiCameraTextOverlay:
           type: string
-
-        # authentication
-        publishUser:
-          type: string
-        publishPass:
-          type: string
-        publishIPs:
-          type: array
-          items:
-            type: string
-        readUser:
-          type: string
-        readPass:
-          type: string
-        readIPs:
-          type: array
-          items:
-            type: string
 
         # external commands
         runOnInit:

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -43,49 +43,13 @@ type PathConf struct {
 	Regexp *regexp.Regexp `json:"-"`
 
 	// source
-	Source                     string         `json:"source"`
-	SourceProtocol             SourceProtocol `json:"sourceProtocol"`
-	SourceAnyPortEnable        bool           `json:"sourceAnyPortEnable"`
+	Source string `json:"source"`
+
+	// general
 	SourceFingerprint          string         `json:"sourceFingerprint"`
 	SourceOnDemand             bool           `json:"sourceOnDemand"`
 	SourceOnDemandStartTimeout StringDuration `json:"sourceOnDemandStartTimeout"`
 	SourceOnDemandCloseAfter   StringDuration `json:"sourceOnDemandCloseAfter"`
-	SourceRedirect             string         `json:"sourceRedirect"`
-	DisablePublisherOverride   bool           `json:"disablePublisherOverride"`
-	Fallback                   string         `json:"fallback"`
-	RPICameraCamID             int            `json:"rpiCameraCamID"`
-	RPICameraWidth             int            `json:"rpiCameraWidth"`
-	RPICameraHeight            int            `json:"rpiCameraHeight"`
-	RPICameraHFlip             bool           `json:"rpiCameraHFlip"`
-	RPICameraVFlip             bool           `json:"rpiCameraVFlip"`
-	RPICameraBrightness        float64        `json:"rpiCameraBrightness"`
-	RPICameraContrast          float64        `json:"rpiCameraContrast"`
-	RPICameraSaturation        float64        `json:"rpiCameraSaturation"`
-	RPICameraSharpness         float64        `json:"rpiCameraSharpness"`
-	RPICameraExposure          string         `json:"rpiCameraExposure"`
-	RPICameraAWB               string         `json:"rpiCameraAWB"`
-	RPICameraDenoise           string         `json:"rpiCameraDenoise"`
-	RPICameraShutter           int            `json:"rpiCameraShutter"`
-	RPICameraMetering          string         `json:"rpiCameraMetering"`
-	RPICameraGain              float64        `json:"rpiCameraGain"`
-	RPICameraEV                float64        `json:"rpiCameraEV"`
-	RPICameraROI               string         `json:"rpiCameraROI"`
-	RPICameraTuningFile        string         `json:"rpiCameraTuningFile"`
-	RPICameraMode              string         `json:"rpiCameraMode"`
-	RPICameraFPS               int            `json:"rpiCameraFPS"`
-	RPICameraIDRPeriod         int            `json:"rpiCameraIDRPeriod"`
-	RPICameraBitrate           int            `json:"rpiCameraBitrate"`
-	RPICameraProfile           string         `json:"rpiCameraProfile"`
-	RPICameraLevel             string         `json:"rpiCameraLevel"`
-	RPICameraAfMode            string         `json:"rpiCameraAfMode"`
-	RPICameraAfRange           string         `json:"rpiCameraAfRange"`
-	RPICameraAfSpeed           string         `json:"rpiCameraAfSpeed"`
-	RPICameraLensPosition      float64        `json:"rpiCameraLensPosition"`
-	RPICameraAfWindow          string         `json:"rpiCameraAfWindow"`
-	RPICameraTextOverlayEnable bool           `json:"rpiCameraTextOverlayEnable"`
-	RPICameraTextOverlay       string         `json:"rpiCameraTextOverlay"`
-	RtspRangeType              RtspRangeType  `json:"rtspRangeType"`
-	RtspRangeStart             string         `json:"rtspRangeStart"`
 
 	// authentication
 	PublishUser Credential `json:"publishUser"`
@@ -94,6 +58,52 @@ type PathConf struct {
 	ReadUser    Credential `json:"readUser"`
 	ReadPass    Credential `json:"readPass"`
 	ReadIPs     IPsOrCIDRs `json:"readIPs"`
+
+	// publisher
+	DisablePublisherOverride bool   `json:"disablePublisherOverride"`
+	Fallback                 string `json:"fallback"`
+
+	// rtsp
+	SourceProtocol      SourceProtocol `json:"sourceProtocol"`
+	SourceAnyPortEnable bool           `json:"sourceAnyPortEnable"`
+	RtspRangeType       RtspRangeType  `json:"rtspRangeType"`
+	RtspRangeStart      string         `json:"rtspRangeStart"`
+
+	// redirect
+	SourceRedirect string `json:"sourceRedirect"`
+
+	// raspberry pi camera
+	RPICameraCamID             int     `json:"rpiCameraCamID"`
+	RPICameraWidth             int     `json:"rpiCameraWidth"`
+	RPICameraHeight            int     `json:"rpiCameraHeight"`
+	RPICameraHFlip             bool    `json:"rpiCameraHFlip"`
+	RPICameraVFlip             bool    `json:"rpiCameraVFlip"`
+	RPICameraBrightness        float64 `json:"rpiCameraBrightness"`
+	RPICameraContrast          float64 `json:"rpiCameraContrast"`
+	RPICameraSaturation        float64 `json:"rpiCameraSaturation"`
+	RPICameraSharpness         float64 `json:"rpiCameraSharpness"`
+	RPICameraExposure          string  `json:"rpiCameraExposure"`
+	RPICameraAWB               string  `json:"rpiCameraAWB"`
+	RPICameraDenoise           string  `json:"rpiCameraDenoise"`
+	RPICameraShutter           int     `json:"rpiCameraShutter"`
+	RPICameraMetering          string  `json:"rpiCameraMetering"`
+	RPICameraGain              float64 `json:"rpiCameraGain"`
+	RPICameraEV                float64 `json:"rpiCameraEV"`
+	RPICameraROI               string  `json:"rpiCameraROI"`
+	RPICameraTuningFile        string  `json:"rpiCameraTuningFile"`
+	RPICameraMode              string  `json:"rpiCameraMode"`
+	RPICameraFPS               int     `json:"rpiCameraFPS"`
+	RPICameraIDRPeriod         int     `json:"rpiCameraIDRPeriod"`
+	RPICameraBitrate           int     `json:"rpiCameraBitrate"`
+	RPICameraProfile           string  `json:"rpiCameraProfile"`
+	RPICameraLevel             string  `json:"rpiCameraLevel"`
+	RPICameraAfMode            string  `json:"rpiCameraAfMode"`
+	RPICameraAfRange           string  `json:"rpiCameraAfRange"`
+	RPICameraAfSpeed           string  `json:"rpiCameraAfSpeed"`
+	RPICameraLensPosition      float64 `json:"rpiCameraLensPosition"`
+	RPICameraAfWindow          string  `json:"rpiCameraAfWindow"`
+	RPICameraTextOverlayEnable bool    `json:"rpiCameraTextOverlayEnable"`
+	RPICameraTextOverlay       string  `json:"rpiCameraTextOverlay"`
 
 	// external commands
 	RunOnInit               string         `json:"runOnInit"`
@@ -341,8 +351,12 @@ func (pconf PathConf) HasOnDemandPublisher() bool {
 func (pconf *PathConf) UnmarshalJSON(b []byte) error {
 	// source
 	pconf.Source = "publisher"
+
+	// general
 	pconf.SourceOnDemandStartTimeout = 10 * StringDuration(time.Second)
 	pconf.SourceOnDemandCloseAfter = 10 * StringDuration(time.Second)
+
+	// raspberry pi camera
 	pconf.RPICameraWidth = 1920
 	pconf.RPICameraHeight = 1080
 	pconf.RPICameraContrast = 1

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -84,7 +84,7 @@ type PathConf struct {
 	RPICameraAfWindow          string         `json:"rpiCameraAfWindow"`
 	RPICameraTextOverlayEnable bool           `json:"rpiCameraTextOverlayEnable"`
 	RPICameraTextOverlay       string         `json:"rpiCameraTextOverlay"`
-	RtspRangeType              string         `json:"rtspRangeType"`
+	RtspRangeType              RtspRangeType  `json:"rtspRangeType"`
 	RtspRangeStart             string         `json:"rtspRangeStart"`
 
 	// authentication

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -84,6 +84,8 @@ type PathConf struct {
 	RPICameraAfWindow          string         `json:"rpiCameraAfWindow"`
 	RPICameraTextOverlayEnable bool           `json:"rpiCameraTextOverlayEnable"`
 	RPICameraTextOverlay       string         `json:"rpiCameraTextOverlay"`
+	RtspRangeType              string         `json:"rtspRangeType"`
+	RtspRangeStart             string         `json:"rtspRangeStart"`
 
 	// authentication
 	PublishUser Credential `json:"publishUser"`

--- a/internal/conf/rtsprangetype.go
+++ b/internal/conf/rtsprangetype.go
@@ -1,0 +1,71 @@
+package conf
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type RtspRangeType int
+
+const (
+	RtspRangeTypeUndefined RtspRangeType = iota
+	RtspRangeTypeClock
+	RtspRangeTypeNPT
+	RtspRangeTypeSMPTE
+)
+
+// MarshalJSON implements json.Marshaler.
+func (d RtspRangeType) MarshalJSON() ([]byte, error) {
+	var out string
+
+	switch d {
+	case RtspRangeTypeClock:
+		out = "clock"
+
+	case RtspRangeTypeNPT:
+		out = "npt"
+
+	case RtspRangeTypeSMPTE:
+		out = "smpte"
+
+	case RtspRangeTypeUndefined:
+		out = ""
+
+	default:
+		return nil, fmt.Errorf("invalid rtsp range type: %v", d)
+	}
+
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (d *RtspRangeType) UnmarshalJSON(b []byte) error {
+	var in string
+	if err := json.Unmarshal(b, &in); err != nil {
+		return err
+	}
+
+	switch in {
+	case "clock":
+		*d = RtspRangeTypeClock
+
+	case "npt":
+		*d = RtspRangeTypeNPT
+
+	case "smpte":
+		*d = RtspRangeTypeSMPTE
+
+	case "":
+		*d = RtspRangeTypeUndefined
+
+	default:
+		return fmt.Errorf("invalid rtsp range type: '%s'", in)
+	}
+
+	return nil
+}
+
+// UnmarshalEnv implements envUnmarshaler.
+func (d *RtspRangeType) UnmarshalEnv(s string) error {
+	return d.UnmarshalJSON([]byte(`"` + s + `"`))
+}

--- a/internal/conf/rtsprangetype.go
+++ b/internal/conf/rtsprangetype.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 )
 
+// RtspRangeType is the type used in the Range header.
 type RtspRangeType int
 
+// supported rtsp range types.
 const (
 	RtspRangeTypeUndefined RtspRangeType = iota
 	RtspRangeTypeClock

--- a/internal/core/rtsp_source.go
+++ b/internal/core/rtsp_source.go
@@ -50,6 +50,7 @@ func (s *rtspSource) Log(level logger.Level, format string, args ...interface{})
 	s.parent.Log(level, "[rtsp source] "+format, args...)
 }
 
+// Create a headers.Range object based on configuration.
 func CreateRangeHeader(cnf *conf.PathConf) *headers.Range {
 	switch cnf.RtspRangeType {
 	case conf.RtspRangeTypeClock:

--- a/internal/core/rtsp_source.go
+++ b/internal/core/rtsp_source.go
@@ -50,8 +50,8 @@ func (s *rtspSource) Log(level logger.Level, format string, args ...interface{})
 	s.parent.Log(level, "[rtsp source] "+format, args...)
 }
 
-// CreateRangeHeader creates a headers.Range object based on configuration.
-func CreateRangeHeader(cnf *conf.PathConf) *headers.Range {
+// createRangeHeader creates a headers.Range object based on configuration.
+func createRangeHeader(cnf *conf.PathConf) *headers.Range {
 	switch cnf.RtspRangeType {
 	case conf.RtspRangeTypeClock:
 		start, _ := time.Parse("20060102T150405Z", cnf.RtspRangeStart)
@@ -185,7 +185,7 @@ func (s *rtspSource) run(ctx context.Context, cnf *conf.PathConf, reloadConf cha
 				}
 			}
 
-			rangeHeader := CreateRangeHeader(cnf)
+			rangeHeader := createRangeHeader(cnf)
 
 			_, err = c.Play(rangeHeader)
 			if err != nil {

--- a/internal/core/rtsp_source.go
+++ b/internal/core/rtsp_source.go
@@ -50,7 +50,7 @@ func (s *rtspSource) Log(level logger.Level, format string, args ...interface{})
 	s.parent.Log(level, "[rtsp source] "+format, args...)
 }
 
-// Create a headers.Range object based on configuration.
+// CreateRangeHeader creates a headers.Range object based on configuration.
 func CreateRangeHeader(cnf *conf.PathConf) *headers.Range {
 	switch cnf.RtspRangeType {
 	case conf.RtspRangeTypeClock:

--- a/internal/core/rtsp_source.go
+++ b/internal/core/rtsp_source.go
@@ -51,8 +51,8 @@ func (s *rtspSource) Log(level logger.Level, format string, args ...interface{})
 }
 
 func CreateRangeHeader(cnf *conf.PathConf) *headers.Range {
-	switch strings.ToLower(cnf.RtspRangeType) {
-	case "clock":
+	switch cnf.RtspRangeType {
+	case conf.RtspRangeTypeClock:
 		start, _ := time.Parse("20060102T150405Z", cnf.RtspRangeStart)
 
 		return &headers.Range{
@@ -60,7 +60,8 @@ func CreateRangeHeader(cnf *conf.PathConf) *headers.Range {
 				Start: start,
 			},
 		}
-	case "npt":
+
+	case conf.RtspRangeTypeNPT:
 		start, _ := time.ParseDuration(cnf.RtspRangeStart)
 
 		return &headers.Range{
@@ -68,7 +69,8 @@ func CreateRangeHeader(cnf *conf.PathConf) *headers.Range {
 				Start: start,
 			},
 		}
-	case "smpte":
+
+	case conf.RtspRangeTypeSMPTE:
 		start, _ := time.ParseDuration(cnf.RtspRangeStart)
 
 		return &headers.Range{
@@ -78,6 +80,10 @@ func CreateRangeHeader(cnf *conf.PathConf) *headers.Range {
 				},
 			},
 		}
+
+	case conf.RtspRangeTypeUndefined:
+		fallthrough
+
 	default:
 		return nil
 	}

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -244,23 +244,16 @@ paths:
     # * rpiCamera -> the stream is provided by a Raspberry Pi Camera
     source: publisher
 
-    # If the source is an RTSP or RTSPS URL, this is the protocol that will be used to
-    # pull the stream. available values are "automatic", "udp", "multicast", "tcp".
-    sourceProtocol: automatic
+    ###############################################
+    # general path parameters
 
-    # Tf the source is an RTSP or RTSPS URL, this allows to support sources that
-    # don't provide server ports or use random server ports. This is a security issue
-    # and must be used only when interacting with sources that require it.
-    sourceAnyPortEnable: no
-
-    # If the source is a RTSPS, RTMPS or HTTPS URL, and the source certificate is self-signed
+    # If the source is a URL, and the source certificate is self-signed
     # or invalid, you can provide the fingerprint of the certificate in order to
     # validate it anyway. It can be obtained by running:
     # openssl s_client -connect source_ip:source_port </dev/null 2>/dev/null | sed -n '/BEGIN/,/END/p' > server.crt
     # openssl x509 -in server.crt -noout -fingerprint -sha256 | cut -d "=" -f2 | tr -d ':'
     sourceFingerprint:
-
-    # If the source is an RTSP or RTMP URL, it will be pulled only when at least
+    # If the source is a URL, it will be pulled only when at least
     # one reader is connected, saving bandwidth.
     sourceOnDemand: no
     # If sourceOnDemand is "yes", readers will be put on hold until the source is
@@ -270,19 +263,65 @@ paths:
     # readers connected and this amount of time has passed.
     sourceOnDemandCloseAfter: 10s
 
-    # If the source is "redirect", this is the RTSP URL which clients will be
-    # redirected to.
-    sourceRedirect:
+    ###############################################
+    # authentication path parameters
 
-    # If the source is "publisher" and a client is publishing, do not allow another
-    # client to disconnect the former and publish in its place.
+    # Username required to publish.
+    # SHA256-hashed values can be inserted with the "sha256:" prefix.
+    publishUser:
+    # Password required to publish.
+    # SHA256-hashed values can be inserted with the "sha256:" prefix.
+    publishPass:
+    # IPs or networks (x.x.x.x/24) allowed to publish.
+    publishIPs: []
+
+    # Username required to read.
+    # SHA256-hashed values can be inserted with the "sha256:" prefix.
+    readUser:
+    # password required to read.
+    # SHA256-hashed values can be inserted with the "sha256:" prefix.
+    readPass:
+    # IPs or networks (x.x.x.x/24) allowed to read.
+    readIPs: []
+
+    ###############################################
+    # publisher path parameters (when source is "publisher")
+
+    # do not allow another client to disconnect the current publisher and publish in its place.
     disablePublisherOverride: no
-
-    # If the source is "publisher" and no one is publishing, redirect readers to this
-    # path. It can be can be a relative path  (i.e. /otherstream) or an absolute RTSP URL.
+    # if no one is publishing, redirect readers to this path.
+    # It can be can be a relative path  (i.e. /otherstream) or an absolute RTSP URL.
     fallback:
 
-    # If the source is "rpiCamera", these are the Raspberry Pi Camera parameters.
+    ###############################################
+    # RTSP path parameters (when source is a RTSP or a RTSPS URL)
+
+    # protocol used to pull the stream. available values are "automatic", "udp", "multicast", "tcp".
+    sourceProtocol: automatic
+    # support sources that don't provide server ports or use random server ports. This is a security issue
+    # and must be used only when interacting with sources that require it.
+    sourceAnyPortEnable: no
+    # range header to send to the source, in order to start streaming from the specified offset.
+    # available values:
+    # * clock: Absolute time
+    # * npt: Normal Play Time
+    # * smpte: SMPTE timestamps relative to the start of the recording
+    rtspRangeType:
+    # available values:
+    # * clock: UTC ISO 8601 combined date and time string, e.g. 20230812T120000Z
+    # * npt: duration such as "300ms", "1.5m" or "2h45m", valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+    # * smpte: duration such as "300ms", "1.5m" or "2h45m", valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+    rtspRangeStart:
+
+    ###############################################
+    # Redirect path parameters (when source is "redirect")
+
+    # RTSP URL which clients will be redirected to.
+    sourceRedirect:
+
+    ###############################################
+    # Raspberry Pi Camera path parameters (when source is "rpiCamera")
+
     # ID of the camera
     rpiCameraCamID: 0
     # width of frames
@@ -360,23 +399,8 @@ paths:
     # format is the one of the strftime() function.
     rpiCameraTextOverlay: '%Y-%m-%d %H:%M:%S - MediaMTX'
 
-    # Username required to publish.
-    # SHA256-hashed values can be inserted with the "sha256:" prefix.
-    publishUser:
-    # Password required to publish.
-    # SHA256-hashed values can be inserted with the "sha256:" prefix.
-    publishPass:
-    # IPs or networks (x.x.x.x/24) allowed to publish.
-    publishIPs: []
-
-    # Username required to read.
-    # SHA256-hashed values can be inserted with the "sha256:" prefix.
-    readUser:
-    # password required to read.
-    # SHA256-hashed values can be inserted with the "sha256:" prefix.
-    readPass:
-    # IPs or networks (x.x.x.x/24) allowed to read.
-    readIPs: []
+    ###############################################
+    # external commands path parameters
 
     # Command to run when this path is initialized.
     # This can be used to publish a stream and keep it always opened.
@@ -430,15 +454,3 @@ paths:
     runOnRead:
     # Restart the command if it exits suddenly.
     runOnReadRestart: no
-
-    # If the source is an RTSP or RTSPS URL, a range header can be set to start streaming from the specified offset
-    # Type of RTSP range header:
-    # * clock: Absolute time
-    # * npt: Normal Play Time
-    # * smpte: SMPTE (Society of Motion Pictures and Television Engineers) timestamps relative to the start of the recording
-    rtspRangeType:
-    # Range start value format per range type:
-    # * clock: UTC ISO 8601 combined date and time string, e.g. 20230812T120000Z
-    # * npt: duration such as "300ms", "1.5m" or "2h45m", valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-    # * smpte: duration such as "300ms", "1.5m" or "2h45m", valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-    rtspRangeStart:

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -245,7 +245,7 @@ paths:
     source: publisher
 
     ###############################################
-    # general path parameters
+    # General path parameters
 
     # If the source is a URL, and the source certificate is self-signed
     # or invalid, you can provide the fingerprint of the certificate in order to
@@ -264,7 +264,7 @@ paths:
     sourceOnDemandCloseAfter: 10s
 
     ###############################################
-    # authentication path parameters
+    # Authentication path parameters
 
     # Username required to publish.
     # SHA256-hashed values can be inserted with the "sha256:" prefix.
@@ -285,7 +285,7 @@ paths:
     readIPs: []
 
     ###############################################
-    # publisher path parameters (when source is "publisher")
+    # Publisher path parameters (when source is "publisher")
 
     # do not allow another client to disconnect the current publisher and publish in its place.
     disablePublisherOverride: no

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -430,3 +430,15 @@ paths:
     runOnRead:
     # Restart the command if it exits suddenly.
     runOnReadRestart: no
+
+    # If the source is an RTSP or RTSPS URL, a range header can be set to start streaming from the specified offset
+    # Type of RTSP range header:
+    # * clock: Absolute time
+    # * npt: Normal Play Time
+    # * smpte: SMPTE (Society of Motion Pictures and Television Engineers) timestamps relative to the start of the recording
+    rtspRangeType:
+    # Range start value format per range type:
+    # * clock: UTC ISO 8601 combined date and time string, e.g. 20230812T120000Z
+    # * npt: duration such as "300ms", "1.5m" or "2h45m", valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+    # * smpte: duration such as "300ms", "1.5m" or "2h45m", valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+    rtspRangeStart:


### PR DESCRIPTION
Send `Range` RTSP header when source is RTSP and configuration options `rtspRangeType` & `rtspRangeStart` are configured.
